### PR TITLE
Backport macros to support Scala 2.10.x on master branch

### DIFF
--- a/project/Common.scala
+++ b/project/Common.scala
@@ -14,8 +14,8 @@ object Common {
     scalariformSettings ++
     List(
       organization := "com.typesafe.scala-logging",
-      scalaVersion := Version.scala,
-      crossScalaVersions := List(scalaVersion.value),
+      scalaVersion := Version.scala.head,
+      crossScalaVersions := Version.scala,
       scalacOptions ++= List(
         "-unchecked",
         "-deprecation",

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,7 +1,7 @@
 import sbt._
 
 object Version {
-  val scala        = "2.11.0"
+  val scala        = List("2.11.0", "2.10.4")
   val slf4j        = "1.7.7"
   val logback      = "1.1.2"
   val scalaTest    = "2.1.3"
@@ -9,7 +9,7 @@ object Version {
 }
 
 object Library {
-  val scalaReflect   = "org.scala-lang" % "scala-reflect"    % Version.scala
+  val scalaReflect   = "org.scala-lang" % "scala-reflect"
   val slf4jApi       = "org.slf4j"      %  "slf4j-api"       % Version.slf4j
   val logbackClassic = "ch.qos.logback" %  "logback-classic" % Version.logback
   val scalaTest      = "org.scalatest"  %% "scalatest"       % Version.scalaTest
@@ -23,8 +23,8 @@ object Dependencies {
   val scalaLoggingApi = List(
   )
 
-  val scalaLoggingSlf4j = List(
-    scalaReflect,
+  def scalaLoggingSlf4j(scalaVersion: String) = List(
+    scalaReflect % scalaVersion,
     slf4jApi,
     scalaTest % "test",
     mockitoAll % "test",

--- a/scala-logging-slf4j/build.sbt
+++ b/scala-logging-slf4j/build.sbt
@@ -1,3 +1,5 @@
 Common.settings
 
-libraryDependencies ++= Dependencies.scalaLoggingSlf4j
+libraryDependencies ++= Dependencies.scalaLoggingSlf4j(scalaVersion.value)
+
+unmanagedSourceDirectories in Compile += (sourceDirectory in Compile).value / s"scala_${scalaBinaryVersion.value}"

--- a/scala-logging-slf4j/src/main/scala_2.10/com/typesafe/scalalogging/slf4j/LoggerMacro.scala
+++ b/scala-logging-slf4j/src/main/scala_2.10/com/typesafe/scalalogging/slf4j/LoggerMacro.scala
@@ -1,0 +1,186 @@
+package com.typesafe.scalalogging.slf4j
+
+import org.slf4j.Marker
+import scala.reflect.macros.Context
+import scala.annotation.switch
+
+private object LoggerMacro {
+
+  type LoggerContext = Context { type PrefixType = Logger }
+
+  // Error
+
+  def errorMessage(c: LoggerContext)(message: c.Expr[String]) =
+    c.universe.reify(
+      if (c.prefix.splice.underlying.isErrorEnabled)
+        c.prefix.splice.underlying.error(message.splice)
+    )
+
+  def errorMessageArgs(c: LoggerContext)(message: c.Expr[String], args: c.Expr[AnyRef]*) =
+    (args.length: @switch) match {
+      case 1 =>
+        c.universe.reify(
+          if (c.prefix.splice.underlying.isErrorEnabled)
+            LoggerSupport.error(c.prefix.splice.underlying, message.splice, args(0).splice)
+        )
+      case 2 =>
+        c.universe.reify(
+          if (c.prefix.splice.underlying.isErrorEnabled)
+            LoggerSupport.error(c.prefix.splice.underlying, message.splice, args(0).splice, args(1).splice)
+        )
+      case _ =>
+        logParams(c)(message, args)("error")
+    }
+
+  def errorMessageCause(c: LoggerContext)(message: c.Expr[String], cause: c.Expr[Throwable]) =
+    c.universe.reify(
+      if (c.prefix.splice.underlying.isErrorEnabled)
+        c.prefix.splice.underlying.error(message.splice, cause.splice)
+    )
+
+  // Warn
+
+  def warnMessage(c: LoggerContext)(message: c.Expr[String]) =
+    c.universe.reify(
+      if (c.prefix.splice.underlying.isWarnEnabled)
+        c.prefix.splice.underlying.warn(message.splice)
+    )
+
+  def warnMessageArgs(c: LoggerContext)(message: c.Expr[String], args: c.Expr[AnyRef]*) =
+    (args.length: @switch) match {
+      case 1 =>
+        c.universe.reify(
+          if (c.prefix.splice.underlying.isWarnEnabled)
+            LoggerSupport.warn(c.prefix.splice.underlying, message.splice, args(0).splice)
+        )
+      case 2 =>
+        c.universe.reify(
+          if (c.prefix.splice.underlying.isWarnEnabled)
+            LoggerSupport.warn(c.prefix.splice.underlying, message.splice, args(0).splice, args(1).splice)
+        )
+      case _ =>
+        logParams(c)(message, args)("warn")
+    }
+
+  def warnMessageCause(c: LoggerContext)(message: c.Expr[String], cause: c.Expr[Throwable]) =
+    c.universe.reify(
+      if (c.prefix.splice.underlying.isWarnEnabled)
+        c.prefix.splice.underlying.warn(message.splice, cause.splice)
+    )
+
+  // Info
+
+  def infoMessage(c: LoggerContext)(message: c.Expr[String]) =
+    c.universe.reify(
+      if (c.prefix.splice.underlying.isInfoEnabled)
+        c.prefix.splice.underlying.info(message.splice)
+    )
+
+  def infoMessageArgs(c: LoggerContext)(message: c.Expr[String], args: c.Expr[AnyRef]*) =
+    (args.length: @switch) match {
+      case 1 =>
+        c.universe.reify(
+          if (c.prefix.splice.underlying.isInfoEnabled)
+            LoggerSupport.info(c.prefix.splice.underlying, message.splice, args(0).splice)
+        )
+      case 2 =>
+        c.universe.reify(
+          if (c.prefix.splice.underlying.isInfoEnabled)
+            LoggerSupport.info(c.prefix.splice.underlying, message.splice, args(0).splice, args(1).splice)
+        )
+      case _ =>
+        logParams(c)(message, args)("info")
+    }
+
+  def infoMessageCause(c: LoggerContext)(message: c.Expr[String], cause: c.Expr[Throwable]) =
+    c.universe.reify(
+      if (c.prefix.splice.underlying.isInfoEnabled)
+        c.prefix.splice.underlying.info(message.splice, cause.splice)
+    )
+
+  // Debug
+
+  def debugMessage(c: LoggerContext)(message: c.Expr[String]) =
+    c.universe.reify(
+      if (c.prefix.splice.underlying.isDebugEnabled)
+        c.prefix.splice.underlying.debug(message.splice)
+    )
+
+  def debugMessageArgs(c: LoggerContext)(message: c.Expr[String], args: c.Expr[AnyRef]*) =
+    (args.length: @switch) match {
+      case 1 =>
+        c.universe.reify(
+          if (c.prefix.splice.underlying.isDebugEnabled)
+            LoggerSupport.debug(c.prefix.splice.underlying, message.splice, args(0).splice)
+        )
+      case 2 =>
+        c.universe.reify(
+          if (c.prefix.splice.underlying.isDebugEnabled)
+            LoggerSupport.debug(c.prefix.splice.underlying, message.splice, args(0).splice, args(1).splice)
+        )
+      case _ =>
+        logParams(c)(message, args)("debug")
+    }
+
+  def debugMessageCause(c: LoggerContext)(message: c.Expr[String], cause: c.Expr[Throwable]) =
+    c.universe.reify(
+      if (c.prefix.splice.underlying.isDebugEnabled)
+        c.prefix.splice.underlying.debug(message.splice, cause.splice)
+    )
+
+  // Trace
+
+  def traceMessage(c: LoggerContext)(message: c.Expr[String]) =
+    c.universe.reify(
+      if (c.prefix.splice.underlying.isTraceEnabled)
+        c.prefix.splice.underlying.trace(message.splice)
+    )
+
+  def traceMessageArgs(c: LoggerContext)(message: c.Expr[String], args: c.Expr[AnyRef]*) =
+    (args.length: @switch) match {
+      case 1 =>
+        c.universe.reify(
+          if (c.prefix.splice.underlying.isTraceEnabled)
+            LoggerSupport.trace(c.prefix.splice.underlying, message.splice, args(0).splice)
+        )
+      case 2 =>
+        c.universe.reify(
+          if (c.prefix.splice.underlying.isTraceEnabled)
+            LoggerSupport.trace(c.prefix.splice.underlying, message.splice, args(0).splice, args(1).splice)
+        )
+      case _ =>
+        logParams(c)(message, args)("trace")
+    }
+
+  def traceMessageCause(c: LoggerContext)(message: c.Expr[String], cause: c.Expr[Throwable]) =
+    c.universe.reify(
+      if (c.prefix.splice.underlying.isTraceEnabled)
+        c.prefix.splice.underlying.trace(message.splice, cause.splice)
+    )
+
+  // Common
+
+  private def logParams(
+                         c: LoggerContext)(
+                         message: c.Expr[String],
+                         params: Seq[c.Expr[AnyRef]])(
+                         level: String) = {
+    import c.universe._
+    val isEnabled = Select(
+      Select(c.prefix.tree, newTermName("underlying")),
+      newTermName(s"is${level.head.toUpper +: level.tail}Enabled")
+    )
+    val paramsWildcard = Typed(
+      Apply(
+        Ident(newTermName("List")),
+        (params map (_.tree)).toList
+      ),
+      Ident(tpnme.WILDCARD_STAR)
+    )
+    val log = Apply(
+      Select(Select(c.prefix.tree, newTermName("underlying")), newTermName(level)),
+      message.tree +: List(paramsWildcard)
+    )
+    c.Expr(If(isEnabled, log, Literal(Constant(()))))
+  }
+}

--- a/scala-logging-slf4j/src/main/scala_2.11/com/typesafe/scalalogging/slf4j/LoggerMacro.scala
+++ b/scala-logging-slf4j/src/main/scala_2.11/com/typesafe/scalalogging/slf4j/LoggerMacro.scala
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-package com.typesafe.scalalogging
-package slf4j
+package com.typesafe.scalalogging.slf4j
 
 import scala.annotation.switch
 import scala.reflect.macros.blackbox.Context


### PR DESCRIPTION
This adds support for Scala 2.10 without any modification to the API or specs.  This will enable libraries that migrate to scala-logging-2.x to continue to cross build for Scala 2.10 and 2.11 without conditionals in the build or creating their own copy of the `Logging` trait.

Relates to #1, #4, #13
