### PR TITLE
Added support for passing in slf4j's marker to log statements.

### DIFF
--- a/src/main/scala/com/typesafe/scalalogging/Logger.scala
+++ b/src/main/scala/com/typesafe/scalalogging/Logger.scala
@@ -19,8 +19,6 @@ package com.typesafe.scalalogging
 import org.slf4j.{ Logger => Underlying }
 import org.slf4j.Marker
 
-import scala.language.experimental.macros
-
 /**
  * Companion for [[Logger]], providing a factory for [[Logger]]s.
  */

--- a/src/main/scala/com/typesafe/scalalogging/LoggerMacro.scala
+++ b/src/main/scala/com/typesafe/scalalogging/LoggerMacro.scala
@@ -16,8 +16,8 @@
 
 package com.typesafe.scalalogging
 
-import scala.reflect.macros.blackbox.Context
 import org.slf4j.Marker
+import scala.reflect.macros.blackbox.Context
 
 private object LoggerMacro {
 

--- a/src/test/scala/com/typesafe/scalalogging/LoggerWithMarkerSpec.scala
+++ b/src/test/scala/com/typesafe/scalalogging/LoggerWithMarkerSpec.scala
@@ -17,7 +17,6 @@
 package com.typesafe.scalalogging
 
 import java.util.NoSuchElementException
-
 import org.mockito.Matchers._
 import org.mockito.Mockito._
 import org.slf4j.{ Logger => Underlying }


### PR DESCRIPTION
Should close https://github.com/typesafehub/scala-logging/issues/17
