### PR TITLE
remove Traversable type alias

### DIFF
--- a/src/main/scala/com/typesafe/scalalogging/package.scala
+++ b/src/main/scala/com/typesafe/scalalogging/package.scala
@@ -18,8 +18,6 @@ package com.typesafe
 
 package object scalalogging {
 
-  type Traversable[+A] = scala.collection.immutable.Traversable[A]
-
   type Iterable[+A] = scala.collection.immutable.Iterable[A]
 
   type Seq[+A] = scala.collection.immutable.Seq[A]


### PR DESCRIPTION
deprecated since Scala 2.13.0-M4

https://github.com/scala/scala/blob/v2.13.0-M4/src/library/scala/package.scala#L44-L47