### PR TITLE
adjust CI config to avoid repeating Scala version numbers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         java: [8, 11, 17]
-        scala: [2.11.12, 2.12.17, 2.13.8, 3.1.3]
+        scala: [2.11.x, 2.12.x, 2.13.x, 3.1.x]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
this recently became possible in recent sbt versions (1.7.x, I think)