### PR TITLE
Fix some varargs issues in scala 2 and scala 3

### DIFF
--- a/src/test/scala-2/com/typesafe/scalalogging/Scala2LoggerSpec.scala
+++ b/src/test/scala-2/com/typesafe/scalalogging/Scala2LoggerSpec.scala
@@ -1,0 +1,45 @@
+package com.typesafe.scalalogging
+
+import org.mockito.Mockito._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatestplus.mockito.MockitoSugar
+import org.slf4j.{ Logger => Underlying }
+
+class Scala2LoggerSpec extends AnyWordSpec with Matchers with Varargs with MockitoSugar {
+
+  // Info
+  "Calling info with an interpolated message, only scala 2" should {
+    "fix Varargs compilation error issue 354 only scala 2" in {
+      val f = fixture(_.isInfoEnabled, isEnabled = true)
+      import f._
+      class LogWrapper(val underlying: Logger) {
+        def info(message: String, args: AnyRef*): Unit = underlying.info(message, args: _*)
+      }
+      val logWrapper = new LogWrapper(logger)
+      logWrapper.info("""Hello {}""", arg5ref)
+      verify(underlying).info("""Hello {}""", forceVarargs(arg5ref): _*)
+    }
+  }
+
+  private def fixture(p: Underlying => Boolean, isEnabled: Boolean) = new LoggerF(p, isEnabled)
+
+  private class LoggerF(p: Underlying => Boolean, isEnabled: Boolean) {
+    val msg = "msg"
+    val cause = new RuntimeException("cause")
+    val arg1 = "arg1"
+    val arg2: Integer = Integer.valueOf(1)
+    val arg3 = "arg3"
+    val arg4 = 4
+    val arg4ref: AnyRef = arg4.asInstanceOf[AnyRef]
+    val arg5 = true
+    val arg5ref: AnyRef = arg5.asInstanceOf[AnyRef]
+    val arg6 = 6L
+    val arg6ref: AnyRef = arg6.asInstanceOf[AnyRef]
+    val arg7 = new Throwable
+    val arg7ref: AnyRef = arg7.asInstanceOf[AnyRef]
+    val underlying: Underlying = mock[org.slf4j.Logger]
+    when(p(underlying)).thenReturn(isEnabled)
+    val logger: Logger = Logger(underlying)
+  }
+}

--- a/src/test/scala-3/com/typesafe/scalalogging/Scala3LoggerSpec.scala
+++ b/src/test/scala-3/com/typesafe/scalalogging/Scala3LoggerSpec.scala
@@ -1,0 +1,44 @@
+package com.typesafe.scalalogging
+
+import org.mockito.Mockito._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatestplus.mockito.MockitoSugar
+import org.slf4j.{Logger => Underlying}
+
+class Scala3LoggerSpec extends AnyWordSpec with Matchers with Varargs with MockitoSugar {
+
+  // Info
+  "Calling info with an interpolated message, only scala 3" should {
+    "fix Varargs compilation error issue 354 only scala 3" in {
+      val f = fixture(_.isInfoEnabled, isEnabled = true)
+      import f._
+      class LogWrapper(val underlying: Logger) {
+        inline def info(message: String, inline args: AnyRef*): Unit = underlying.info(message, args: _*)
+      }
+      val logWrapper = new LogWrapper(logger)
+      logWrapper.info("""Hello {}""", arg5ref)
+      verify(underlying).info("""Hello {}""", arg5ref)
+    }
+  }
+
+  private def fixture(p: Underlying => Boolean, isEnabled: Boolean) = new LoggerF(p, isEnabled)
+  private class LoggerF(p: Underlying => Boolean, isEnabled: Boolean) {
+    val msg = "msg"
+    val cause = new RuntimeException("cause")
+    val arg1 = "arg1"
+    val arg2: Integer = Integer.valueOf(1)
+    val arg3 = "arg3"
+    val arg4 = 4
+    val arg4ref: AnyRef = arg4.asInstanceOf[AnyRef]
+    val arg5 = true
+    val arg5ref: AnyRef = arg5.asInstanceOf[AnyRef]
+    val arg6 = 6L
+    val arg6ref: AnyRef = arg6.asInstanceOf[AnyRef]
+    val arg7 = new Throwable
+    val arg7ref: AnyRef = arg7.asInstanceOf[AnyRef]
+    val underlying: Underlying = mock[org.slf4j.Logger]
+    when(p(underlying)).thenReturn(isEnabled)
+    val logger: Logger = Logger(underlying)
+  }
+}

--- a/src/test/scala/com/typesafe/scalalogging/LoggerSpec.scala
+++ b/src/test/scala/com/typesafe/scalalogging/LoggerSpec.scala
@@ -207,6 +207,14 @@ class LoggerSpec extends AnyWordSpec with Matchers with Varargs with MockitoSuga
       logger.info(s"msg $arg1 $arg2")
       verify(underlying).info("msg {} {}", forceVarargs(arg1, arg2): _*)
     }
+
+    "fix Varargs compilation error, issue 191" in {
+      val f = fixture(_.isInfoEnabled, isEnabled = true)
+      import f._
+      val message = "Hello"
+      logger.info(s"Message with id=$message, submittedAt=$message will be dropped.")
+      verify(underlying).info("""Message with id={}, submittedAt={} will be dropped.""", forceVarargs(message, message): _*)
+    }
   }
 
   "Calling info with a message and cause" should {


### PR DESCRIPTION
After wrapping varargs, the user code fails to compile.

In Scala 2, there were no inline parameters, and the subtype of args was obtained during compilation. However, this approach may not always be accurate.

Regarding https://github.com/lightbend-labs/scala-logging/issues/191

There is an issue with obtaining inline parameters in Scala 3.

To address this, we recursively obtain the actual value of inline parameters. This necessitates the ongoing use of inlining in the parameters of the wrapper function. For instance:

```scala
class LogWrapper(val underlying: Logger) {
    inline def info(message: String, inline args: AnyRef*): Unit = underlying.info(message, args: _*)
}
```
This ensures compatibility and accurate handling of inline parameters in both Scala 2 and Scala 3.